### PR TITLE
Replace conscript dependecy with BouncyCaste

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.9.2'
+        classpath 'com.android.tools.build:gradle:8.11.1'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/libadb/build.gradle
+++ b/libadb/build.gradle
@@ -52,7 +52,8 @@ publishing {
 
 dependencies {
     implementation "androidx.annotation:annotation:1.9.1"
-    implementation 'org.bouncycastle:bcprov-jdk15to18:1.81'
+    implementation 'org.bouncycastle:bcprov-jdk15to18:1.84'
+    implementation 'org.bouncycastle:bctls-jdk15to18:1.84'
     implementation 'com.github.MuntashirAkon.spake2-java:spake2-android:2.2.1'
 
     testImplementation 'junit:junit:4.13.2'

--- a/libadb/src/main/java/io/github/muntashirakon/adb/PairingConnectionCtx.java
+++ b/libadb/src/main/java/io/github/muntashirakon/adb/PairingConnectionCtx.java
@@ -32,6 +32,8 @@ import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLServerSocket;
 import javax.net.ssl.SSLSocket;
 
+import org.bouncycastle.jsse.BCSSLSocket;
+
 // https://github.com/aosp-mirror/platform_system_core/blob/android-11.0.0_r1/adb/pairing_connection/pairing_connection.cpp
 // Also based on Shizuku's implementation
 @RequiresApi(Build.VERSION_CODES.GINGERBREAD)
@@ -125,7 +127,7 @@ public final class PairingConnectionCtx implements Closeable {
         if (mRole == Role.Server) {
             SSLServerSocket sslServerSocket = (SSLServerSocket) mSslContext.getServerSocketFactory().createServerSocket(mPort);
             socket = sslServerSocket.accept();
-            // TODO: Write automated test scripts after removing Conscrypt dependency.
+            // TODO: Write automated test scripts.
         } else { // role == Role.Client
             socket = new Socket(mHost, mPort);
         }
@@ -141,7 +143,8 @@ public final class PairingConnectionCtx implements Closeable {
 
         // To ensure the connection is not stolen while we do the PAKE, append the exported key material from the
         // tls connection to the password.
-        byte[] keyMaterial = exportKeyingMaterial(sslSocket, EXPORT_KEY_SIZE);
+        BCSSLSocket bcsslsocket = ((BCSSLSocket) sslSocket);
+        byte[] keyMaterial = bcsslsocket.getBCSession().exportKeyingMaterialData(EXPORTED_KEY_LABEL, null, EXPORT_KEY_SIZE);
         byte[] passwordBytes = new byte[mPswd.length + keyMaterial.length];
         System.arraycopy(mPswd, 0, passwordBytes, 0, mPswd.length);
         System.arraycopy(keyMaterial, 0, passwordBytes, mPswd.length, keyMaterial.length);
@@ -151,31 +154,6 @@ public final class PairingConnectionCtx implements Closeable {
             throw new IOException("Unable to create PairingAuthCtx.");
         }
         this.mPairingAuthCtx = pairingAuthCtx;
-    }
-
-    @SuppressLint("PrivateApi") // Conscrypt is a stable private API
-    private byte[] exportKeyingMaterial(SSLSocket sslSocket, int length) throws SSLException {
-        // Conscrypt#exportKeyingMaterial(SSLSocket socket, String label, byte[] context, int length): byte[]
-        //          throws SSLException
-        try {
-            Class<?> conscryptClass;
-            if (SslUtils.isCustomConscrypt()) {
-                conscryptClass = Class.forName("org.conscrypt.Conscrypt");
-            } else if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
-                // Although support for conscrypt has been added in Android 5.0 (Lollipop),
-                // TLS1.3 isn't supported until Android 9 (Pie).
-                throw new SSLException("TLSv1.3 isn't supported on your platform. Use custom Conscrypt library instead.");
-            } else {
-                conscryptClass = Class.forName("com.android.org.conscrypt.Conscrypt");
-            }
-            Method exportKeyingMaterial = conscryptClass.getMethod("exportKeyingMaterial", SSLSocket.class,
-                    String.class, byte[].class, int.class);
-            return (byte[]) exportKeyingMaterial.invoke(null, sslSocket, EXPORTED_KEY_LABEL, null, length);
-        } catch (SSLException e) {
-            throw e;
-        } catch (Throwable th) {
-            throw new SSLException(th);
-        }
     }
 
     private void writeHeader(@NonNull PairingPacketHeader header, @NonNull byte[] payload) throws IOException {

--- a/libadb/src/main/java/io/github/muntashirakon/adb/SslUtils.java
+++ b/libadb/src/main/java/io/github/muntashirakon/adb/SslUtils.java
@@ -3,7 +3,6 @@
 package io.github.muntashirakon.adb;
 
 import android.annotation.SuppressLint;
-import android.os.Build;
 
 import androidx.annotation.NonNull;
 
@@ -21,13 +20,11 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.X509ExtendedKeyManager;
 import javax.net.ssl.X509TrustManager;
 
-final class SslUtils {
-    private static boolean customConscrypt = false;
-    private static SSLContext sslContext;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.jsse.provider.BouncyCastleJsseProvider;
 
-    public static boolean isCustomConscrypt() {
-        return customConscrypt;
-    }
+final class SslUtils {
+    private static SSLContext sslContext;
 
     @SuppressLint("TrulyRandom") // The users are already instructed to fix this issue
     @NonNull
@@ -35,22 +32,11 @@ final class SslUtils {
         if (sslContext != null) {
             return sslContext;
         }
-        try {
-            Class<?> providerClass = Class.forName("org.conscrypt.OpenSSLProvider");
-            Provider openSslProvder = (Provider) providerClass.getDeclaredConstructor().newInstance();
-            sslContext = SSLContext.getInstance("TLSv1.3", openSslProvder);
-            customConscrypt = true;
-        } catch (NoSuchAlgorithmException e) {
-            throw e;
-        } catch (Throwable e) {
-            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
-                // Custom error message to inform user that they should use custom Conscrypt library.
-                throw new NoSuchAlgorithmException("TLSv1.3 isn't supported on your platform. Use custom Conscrypt library instead.");
-            }
-            sslContext = SSLContext.getInstance("TLSv1.3");
-            customConscrypt = false;
-        }
-        System.out.println("Using " + (customConscrypt ? "custom" : "default") + " TLSv1.3 provider...");
+        Provider bcProvider = new BouncyCastleProvider();
+        Provider bcJsseProvider = new BouncyCastleJsseProvider(bcProvider);
+        sslContext = SSLContext.getInstance("TLSv1.3", bcJsseProvider);
+        System.out.println("Using BouncyCastle TLSv1.3 provider...");
+        
         sslContext.init(new KeyManager[]{getKeyManager(keyPair)},
                 new X509TrustManager[]{getAllAcceptingTrustManager()},
                 new SecureRandom());


### PR DESCRIPTION
As per issue https://github.com/MuntashirAkon/libadb-android/issues/28, this pull request replace the conscrypt dependency (in its custom and reflection approaches) with BouncyCastle's TLS library.